### PR TITLE
更新查询接口

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,16 +23,23 @@ function translate(query, completion) {
     $log.info(`搜索请求 query.text: ${query.text}`);
     const search_resp = await $http.request({
       method: "POST",
-      url: "https://api.mojidict.com/parse/functions/search-all",
+      url: "https://api.mojidict.com/parse/functions/union-api",
       header,
       timeout: 10,
       body: {
-        "types": ["102", "103", "106", "431"],
-        "text": query.text,
-        "inputMethod": 0,
-        "g_langEnv": "ja_zh-CN",
-        "g_os": "iOS"
+        g_ver: "v4.8.8.20240829",
+        g_os: "iOS",
+        functions: [
+          {
+            name: "search-all",
+            params: {
+              text: query.text,
+              types: ["102", "103", "106", "431"],
+            },
+          },
+        ],
       },
+
     });
 
     if (search_resp.error) {
@@ -45,7 +52,7 @@ function translate(query, completion) {
       });
     } else {
       $log.info(`搜索请求结果 search_data: ${JSON.stringify(search_resp.data)}`);
-      const search_data = search_resp.data.result.result;
+      const search_data = search_resp.data.result.results['search-all'].result;
       if (search_data.word === undefined || search_data.word.searchResult.length === 0) {
         completion({
           error: {


### PR DESCRIPTION
修正问题：#2 

抓包发现接口地址变了，换成了 union-api 做联查。

body 中的 g_ver 需要传版本号，否则返回空数据，目前也是抓包发现的，可能后续还会变更，目前暂时能用。

`
{
        g_ver: "v4.8.8.20240829",
        g_os: "iOS",
        functions: [
          {
            name: "search-all",
            params: {
              text: query.text,
              types: ["102", "103", "106", "431"],
            },
          },
        ],
      },
`